### PR TITLE
Update the donut chart to be more flexible

### DIFF
--- a/src/widgetastic_patternfly4/donutchart.py
+++ b/src/widgetastic_patternfly4/donutchart.py
@@ -35,7 +35,7 @@ class DonutChart(View):
 
     @View.nested
     class donut(View):  # noqa
-        ROOT = "./div[contains(@class, 'chart-container')]"
+        ROOT = ".//div[contains(@class, 'chart-container')]"
         label = Text(locator="(.//*[name()='svg' and contains(@class, 'chart-label')]"
                      "/*[name()='text']/*[name()='tspan'])[1]")
 
@@ -48,7 +48,10 @@ class DonutChart(View):
 
     @View.nested
     class legend(View):  # noqa
-        ROOT = "./div[not(contains(@class, 'chart-container'))]"
+        ROOT = (
+            ".//div[contains(@class, 'VictoryContainer') "
+            "and not(ancestor::div[contains(@class, 'chart-container')])]"
+        )
         ALL_ITEMS = "./*[name()='svg']/*[name()='text']/*[name()='tspan']"
 
         @ParametrizedView.nested


### PR DESCRIPTION
The implementation of the PF4 donut widget is very flexible, and allows developers to place certain elements where they want to. This PR expands the XPath to match that more flexible implementation.