### PR TITLE
Updated Tab and Pagination widget per recent changes

### DIFF
--- a/src/widgetastic_patternfly4/pagination.py
+++ b/src/widgetastic_patternfly4/pagination.py
@@ -88,11 +88,16 @@ class Pagination(View):
         return self._options.items
 
     def set_per_page(self, count):
-        if not self._options.has_item(str(count)):
+        # support both digits (20 or "20") and exact string value ("20 per page")
+        if not isinstance(count, str) or count.isdigit():
+            value = '{} per page'.format(str(count))
+        else:
+            value = count
+        if not self._options.has_item(value):
             raise ValueError(
                 "count '{}' is not a valid option in the pagination dropdown".format(count))
 
-        self._options.item_select(str(count))
+        self._options.item_select(value)
 
     def __iter__(self):
         self.first_page()

--- a/src/widgetastic_patternfly4/tabs.py
+++ b/src/widgetastic_patternfly4/tabs.py
@@ -21,7 +21,7 @@ class Tab(View):
 
     ROOT = ParametrizedLocator(
         './/section[@aria-labelledby=string('
-        'preceding-sibling::div/ul/li/button[normalize-space(.)={@tab_name|quote}]/@id)]'
+        'preceding-sibling::ul/li/button[normalize-space(.)={@tab_name|quote}]/@id)]'
     )
 
     @property

--- a/testing/test_pagination.py
+++ b/testing/test_pagination.py
@@ -61,7 +61,12 @@ def test_last_page(paginator):
 
 
 def test_per_page_options(paginator):
-    assert paginator.per_page_options == ["10", "20", "50", "100"]
+    assert paginator.per_page_options == [
+        "10 per page",
+        "20 per page",
+        "50 per page",
+        "100 per page"
+    ]
 
 
 @pytest.mark.parametrize("items_per_page", [10, 20, 50, 100])


### PR DESCRIPTION
Tabs have small change in DOM - no extra `div` is needed anymore for ROOT locator.
Pagination now has string values in per_page dropdown - like `10 per page`, `20 per page` etc.