### PR TITLE
Updated Navigation locators with `id` instead of specific text values

### DIFF
--- a/testing/test_nav.py
+++ b/testing/test_nav.py
@@ -5,7 +5,7 @@ from widgetastic_patternfly4 import Navigation
 NAVS = [
     (".//nav[@id='nav-primary-simple']", ["Link 1", "Link 2", "Link 3", "Link 4"],
         ["Link 1"]),
-    (".//h4[normalize-space(.)='Nav (expandable)']/following::div/nav", {
+    (".//h4[@id='expandable-nav']/following::div/nav", {
         "Link 1":
         ["Subnav Link 1", "Subnav Link 2",
          "Subnav Link 3"],
@@ -14,7 +14,7 @@ NAVS = [
          "Subnav Link 3"]
     },
         ["Link 1", "Subnav Link 1"]),
-    (".//h4[normalize-space(.)='Nav (mixed)']/following::div/nav", {
+    (".//h4[@id='nav-mixed']/following::div/nav", {
         "Link 1 (not expandable)": None,
         "Link 2 - expandable":
         ["Link 1", "Link 2", "Link 3"],
@@ -34,7 +34,7 @@ def test_navigation(browser, sample):
 
 
 def test_navigation_select(browser):
-    loc = ".//h4[normalize-space(.)='Nav (mixed)']/following::div/nav"
+    loc = ".//h4[@id='nav-mixed']/following::div/nav"
     nav = Navigation(browser, locator=loc)
     nav.select("Link 3 - expandable", "Link 2")
     assert nav.currently_selected == ["Link 3 - expandable", "Link 2"]


### PR DESCRIPTION
Titles changed yet again, but this time `id`s were added as well, updating locators to use `id` so hopefully we won't have to update them anymore.